### PR TITLE
Bump Kotlin to 1.5.31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ ext {
 
     androidXAnnotations = '1.0.1'
     coroutinesVersion = '1.4.1'
-    roomVersion = '2.2.5'
+    roomVersion = '2.3.0'
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,9 +101,7 @@ dependencies {
     implementation "androidx.room:room-ktx:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
 
-    // kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+
     implementation "org.koin:koin-android-viewmodel:$koin_version"
 
     implementation "androidx.annotation:annotation:$androidXAnnotations"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'androidx.navigation.safeargs'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,9 +80,7 @@ ext {
     koin_version = "2.0.1"
 
     androidXAnnotations = '1.0.1'
-
-    coroutinesVersion = '1.2.1'
-
+    coroutinesVersion = '1.4.1'
     roomVersion = '2.2.5'
 }
 

--- a/app/src/main/java/ir/kindnesswall/data/model/BaseDataSource.kt
+++ b/app/src/main/java/ir/kindnesswall/data/model/BaseDataSource.kt
@@ -44,7 +44,7 @@ abstract class BaseDataSource(val context: Context) {
         maxDelay: Long = 10000,
         factor: Double = 2.0,
         call: suspend () -> Response<T>
-    ) = flow {
+    ) = flow<CustomResult<T>> {
         var loopTimes = times
         var currentDelay = initialDelay
         loop@ while (loopTimes - 1 != 0) {
@@ -52,7 +52,7 @@ abstract class BaseDataSource(val context: Context) {
             val response = getResult(call)
             when (response.status) {
                 CustomResult.Status.SUCCESS -> {
-                   emit(CustomResult.success(response.data))
+                   emit(CustomResult.success(response.data!!))
                     break@loop
                 }
                 CustomResult.Status.ERROR -> {

--- a/app/src/main/java/ir/kindnesswall/data/repository/AuthRepo.kt
+++ b/app/src/main/java/ir/kindnesswall/data/repository/AuthRepo.kt
@@ -1,7 +1,6 @@
 package ir.kindnesswall.data.repository
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.liveData
@@ -30,27 +29,27 @@ class AuthRepo(context: Context, private var authApi: AuthApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         phoneNumber: String
     ): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
                 authApi.registerUser(RegisterBaseModel(phoneNumber))
-            }.collect { result ->
+            }.collect { result: CustomResult<Any> ->
                 when (result.status) {
                     CustomResult.Status.SUCCESS -> {
                         emit(CustomResult.success(result.data))
                     }
                     CustomResult.Status.ERROR -> {
-                        emit(CustomResult.error(result.errorMessage))
+                        emit(CustomResult.error<Any>(result.errorMessage))
                     }
-                    CustomResult.Status.LOADING -> emit(CustomResult.loading())
+                    CustomResult.Status.LOADING -> emit(CustomResult.loading<Any>())
                 }
             }
         }
 
     fun loginUser(viewModelScope: CoroutineScope, phoneNumber: String, verificationCode: String):
-            LiveData<CustomResult<LoginResponseModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        LiveData<CustomResult<LoginResponseModel>> =
+        liveData<CustomResult<LoginResponseModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {

--- a/app/src/main/java/ir/kindnesswall/data/repository/CharityRepo.kt
+++ b/app/src/main/java/ir/kindnesswall/data/repository/CharityRepo.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.collect
 class CharityRepo(context: Context, var charityApi: CharityApi) : BaseDataSource(context) {
 
     fun getCharities(viewModelScope: CoroutineScope): LiveData<CustomResult<List<CharityModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<CharityModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { charityApi.getCharities() }
@@ -49,7 +49,7 @@ class CharityRepo(context: Context, var charityApi: CharityApi) : BaseDataSource
 
     fun getCharity(viewModelScope: CoroutineScope, charityId: Long):
             LiveData<CustomResult<CharityModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<CharityModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { charityApi.getCharity(charityId) }

--- a/app/src/main/java/ir/kindnesswall/data/repository/ChatRepo.kt
+++ b/app/src/main/java/ir/kindnesswall/data/repository/ChatRepo.kt
@@ -31,7 +31,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
     fun getConversationList(
         viewModelScope: CoroutineScope
     ): LiveData<CustomResult<List<ChatContactModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<ChatContactModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy { chatApi.getConversations() }.collect { result ->
                 when (result.status) {
@@ -69,7 +69,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
         lastId: Long,
         chatId: Long
     ): LiveData<CustomResult<ChatMessageModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<ChatMessageModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 chatApi.getChats(GetChatsRequestModel(chatId, beforeId = lastId))
@@ -94,7 +94,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         chatId: Long
     ): LiveData<CustomResult<ChatMessageModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<ChatMessageModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy { chatApi.getChats(GetChatsRequestModel(chatId)) }.collect { result ->
                 when (result.status) {
@@ -118,7 +118,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
         chatId: Long,
         message: String,
         type: String? = null
-    ): LiveData<CustomResult<TextMessageModel>> = liveData(viewModelScope.coroutineContext, 0) {
+    ): LiveData<CustomResult<TextMessageModel>> = liveData<CustomResult<TextMessageModel>>(viewModelScope.coroutineContext, 0) {
         emit(CustomResult.loading())
 
         getResultWithExponentialBackoffStrategy {
@@ -141,7 +141,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
     }
 
     fun blockChat(viewModelScope: CoroutineScope, chatId: Long): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { chatApi.blockChat(chatId) }.collect { result ->
@@ -156,7 +156,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
         }
 
     fun unblockChat(viewModelScope: CoroutineScope, chatId: Long): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { chatApi.unblockChat(chatId) }.collect { result ->
@@ -171,10 +171,10 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
         }
 
     fun getBlockedUsers(viewModelScope: CoroutineScope): LiveData<CustomResult<List<ChatContactModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<ChatContactModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             getResultWithExponentialBackoffStrategy {
                 chatApi.getBlockedUsers()
-            }.collect { result ->
+            }.collect { result: CustomResult<List<ChatContactModel>> ->
                 when (result.status) {
                     CustomResult.Status.SUCCESS -> {
                         emitSource(MutableLiveData<List<ChatContactModel>>().apply {
@@ -201,7 +201,7 @@ class ChatRepo(context: Context, private var chatApi: ChatApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         charityId: Long
     ): LiveData<CustomResult<ChatContactModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<ChatContactModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 chatApi.getChatId(charityId)

--- a/app/src/main/java/ir/kindnesswall/data/repository/GeneralRepo.kt
+++ b/app/src/main/java/ir/kindnesswall/data/repository/GeneralRepo.kt
@@ -28,7 +28,7 @@ class GeneralRepo(context: Context, var generalApi: GeneralApi, var appDatabase:
     BaseDataSource(context) {
 
     fun getProvinces(viewModelScope: CoroutineScope): LiveData<CustomResult<List<ProvinceModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<ProvinceModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             fun fetchFromDb() = appDatabase.provinceDao().getAll().map { CustomResult.success(it) }
 
             emit(CustomResult.loading())
@@ -57,7 +57,7 @@ class GeneralRepo(context: Context, var generalApi: GeneralApi, var appDatabase:
         viewModelScope: CoroutineScope,
         provinceId: Int
     ): LiveData<CustomResult<List<CityModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<CityModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 generalApi.getCities(provinceId)
@@ -82,7 +82,7 @@ class GeneralRepo(context: Context, var generalApi: GeneralApi, var appDatabase:
         viewModelScope: CoroutineScope,
         cityId: Int
     ): LiveData<CustomResult<List<RegionModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<RegionModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 generalApi.getRegions(cityId)
@@ -104,7 +104,7 @@ class GeneralRepo(context: Context, var generalApi: GeneralApi, var appDatabase:
         }
 
     fun getAllCatgories(viewModelScope: CoroutineScope): LiveData<CustomResult<List<CategoryModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<CategoryModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { generalApi.getAllCategories() }
@@ -126,7 +126,7 @@ class GeneralRepo(context: Context, var generalApi: GeneralApi, var appDatabase:
         }
 
     fun getVersion(viewModelScope: CoroutineScope): LiveData<CustomResult<UpdateModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<UpdateModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { generalApi.getVersion() }
@@ -150,7 +150,7 @@ class GeneralRepo(context: Context, var generalApi: GeneralApi, var appDatabase:
 
 
     fun getSetting(viewModelScope: CoroutineScope): LiveData<CustomResult<SettingModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<SettingModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy{generalApi.getSetting()}.collect{ result->
                 when (result.status){

--- a/app/src/main/java/ir/kindnesswall/data/repository/GiftRepo.kt
+++ b/app/src/main/java/ir/kindnesswall/data/repository/GiftRepo.kt
@@ -32,7 +32,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         lastId: Long
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 giftApi.getGifts(GetGiftsRequestBaseBody().apply { beforeId = lastId })
@@ -58,7 +58,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         lastId: Long,
         getGiftsRequestBody: GetGiftsRequestBaseBody
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
@@ -84,7 +84,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         registerGiftRequestModel: RegisterGiftRequestModel
     ): LiveData<CustomResult<GiftModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<GiftModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 giftApi.registerGift(registerGiftRequestModel)
@@ -109,7 +109,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         registerGiftRequestModel: RegisterGiftRequestModel
     ): LiveData<CustomResult<GiftModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<GiftModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 giftApi.updateGift(registerGiftRequestModel.id.toLong(), registerGiftRequestModel)
@@ -132,7 +132,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
 
     fun requestGift(viewModelScope: CoroutineScope, giftId: Long):
             LiveData<CustomResult<ChatContactModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<ChatContactModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy { giftApi.requestGift(giftId) }
                 .collect { result ->
@@ -156,7 +156,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         userId: Long
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 giftApi.getToDonateGifts(userId, GetGiftsRequestBaseBody().apply {
@@ -186,7 +186,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         giftId: Long,
         userToDonateId: Long
     ): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 giftApi.donateGift(DonateGiftRequestModel(giftId, userToDonateId))
@@ -204,7 +204,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
     fun getReviewGiftsFirstPage(
         viewModelScope: CoroutineScope
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 giftApi.getReviewGiftsFirstPage(GetGiftsRequestBaseBody())
@@ -229,7 +229,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         lastId: Long
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
@@ -259,7 +259,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         giftId: Long,
         rejectReason: String
     ): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
@@ -279,7 +279,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         giftId: Long
     ): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
@@ -299,7 +299,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         giftId: Long
     ): LiveData<CustomResult<GiftRequestStatusModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<GiftRequestStatusModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
@@ -323,7 +323,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         userId: Long
     ): LiveData<CustomResult<SettingModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<SettingModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy { giftApi.getSetting(userId) }.collect { result ->
                 when (result.status) {
@@ -341,7 +341,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         userId: Long
     ): LiveData<CustomResult<PhoneNumberModel>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<PhoneNumberModel>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy { giftApi.getUserNumber(userId) }.collect() { result ->
                 when (result.status) {
@@ -363,7 +363,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         giftId: Long
     ): LiveData<CustomResult<Any?>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy { giftApi.deleteGift(giftId) }.collect { result ->
                 when (result.status) {
@@ -381,7 +381,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
     fun setSettingNumber(
         viewModelScope: CoroutineScope,
         value: String
-    ): LiveData<CustomResult<Any?>> = liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+    ): LiveData<CustomResult<Any?>> = liveData<CustomResult<Any?>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
         emit(CustomResult.loading())
         getResultWithExponentialBackoffStrategy { giftApi.setPhoneVisibilitySetting(SetSetting(value)) }.collect { result ->
             when (result.status) {
@@ -397,7 +397,7 @@ class GiftRepo(context: Context, private val giftApi: GiftApi) : BaseDataSource(
         }
 
     }
-    fun getSettingNumber(viewModelScope: CoroutineScope):LiveData<CustomResult<SettingModel?>> = liveData(viewModelScope.coroutineContext,timeoutInMs = 0){
+    fun getSettingNumber(viewModelScope: CoroutineScope):LiveData<CustomResult<SettingModel?>> = liveData<CustomResult<SettingModel?>>(viewModelScope.coroutineContext,timeoutInMs = 0){
         emit(CustomResult.loading())
         getResultWithExponentialBackoffStrategy{giftApi.getPhoneVisibilitySetting()}.collect{result ->
             when (result.status) {

--- a/app/src/main/java/ir/kindnesswall/data/repository/UserRepo.kt
+++ b/app/src/main/java/ir/kindnesswall/data/repository/UserRepo.kt
@@ -35,7 +35,7 @@ import retrofit2.Response
 class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(context) {
     fun getUserProfile(viewModelScope: CoroutineScope):
             LiveData<CustomResult<User>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<User>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy {
@@ -61,7 +61,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
 
     fun getUserProfile(viewModelScope: CoroutineScope, userId: Long):
             LiveData<CustomResult<User>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<User>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
 
             getResultWithExponentialBackoffStrategy { userApi.getUserProfile(userId) }.collect { result ->
@@ -84,7 +84,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
         userName: String,
         imageUrl: String
     ): LiveData<CustomResult<Any>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<Any>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             emit(CustomResult.loading())
             getResultWithExponentialBackoffStrategy {
                 userApi.updateUserProfile(UpdateProfileRequestBaseModel(userName, imageUrl))
@@ -108,7 +108,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
 
     fun getOtherUsersProfile(viewModelScope: CoroutineScope, userId: Long?):
             LiveData<CustomResult<User>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<User>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             if (userId == null) {
                 emit(CustomResult.error(CustomResult.ErrorMessage()))
                 return@liveData
@@ -135,7 +135,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
 
     fun getUserReceivedGifts(viewModelScope: CoroutineScope, userId: Long?):
             LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             if (userId == null) {
                 emit(CustomResult.error(CustomResult.ErrorMessage()))
                 return@liveData
@@ -162,7 +162,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
 
     fun getUserDonatedGifts(viewModelScope: CoroutineScope, userId: Long?):
             LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             if (userId == null) {
                 emit(CustomResult.error(CustomResult.ErrorMessage()))
                 return@liveData
@@ -189,7 +189,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
 
     fun getUserRegisteredGifts(viewModelScope: CoroutineScope, userId: Long?):
             LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             if (userId == null) {
                 emit(CustomResult.error(CustomResult.ErrorMessage()))
                 return@liveData
@@ -236,7 +236,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         userId: Long
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             if (userId == null) {
                 emit(CustomResult.error(CustomResult.ErrorMessage()))
                 return@liveData
@@ -266,7 +266,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
         viewModelScope: CoroutineScope,
         userId: Long
     ): LiveData<CustomResult<List<GiftModel>>> =
-        liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+        liveData<CustomResult<List<GiftModel>>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
             if (userId == null) {
                 emit(CustomResult.error(CustomResult.ErrorMessage()))
                 return@liveData
@@ -298,7 +298,7 @@ class UserRepo(context: Context, private val userApi: UserApi) : BaseDataSource(
     fun setUserPhoneSetting(
         viewModelScope: CoroutineScope,
         setting: String
-    ): LiveData<CustomResult<Any>> = liveData(viewModelScope.coroutineContext, timeoutInMs = 0) {
+    ): LiveData<CustomResult<Any>> = liveData<CustomResult<Any>>(viewModelScope.coroutineContext, timeoutInMs = 0) {
         Log.i("56456465456", "Run2")
         emit(CustomResult.loading())
         getResultWithExponentialBackoffStrategy {

--- a/app/src/main/java/ir/kindnesswall/utils/NumberStatus.kt
+++ b/app/src/main/java/ir/kindnesswall/utils/NumberStatus.kt
@@ -2,16 +2,12 @@ package ir.kindnesswall.utils
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
-import android.view.View
 import android.widget.RadioButton
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.observe
 import ir.kindnesswall.data.local.UserInfoPref
 import ir.kindnesswall.data.model.CustomResult
 import ir.kindnesswall.view.main.addproduct.SubmitGiftViewModel
-import kotlinx.android.synthetic.main.activity_submit_gift.*
-import org.koin.android.viewmodel.ext.android.viewModel
 
 class NumberStatus(
     val viewModel: SubmitGiftViewModel,

--- a/app/src/main/java/ir/kindnesswall/view/main/addproduct/SubmitGiftActivity.kt
+++ b/app/src/main/java/ir/kindnesswall/view/main/addproduct/SubmitGiftActivity.kt
@@ -7,8 +7,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
-import android.view.View
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.observe
@@ -31,8 +29,6 @@ import ir.kindnesswall.view.category.CategoryActivity
 import ir.kindnesswall.view.citychooser.CityChooserActivity
 import ir.kindnesswall.view.giftdetail.GiftDetailActivity
 import ir.kindnesswall.view.main.MainActivity
-import kotlinx.android.synthetic.main.activity_submit_gift.*
-import kotlinx.android.synthetic.main.fragment_more.*
 import org.koin.android.viewmodel.ext.android.viewModel
 
 class SubmitGiftActivity : BaseActivity() {
@@ -77,7 +73,7 @@ class SubmitGiftActivity : BaseActivity() {
             fillWithEditableGift()
         }
 
-        val numberstatus = NumberStatus(viewModel ,submit_none , submit_charity , submit_all )
+        val numberstatus = NumberStatus(viewModel, binding.submitNone, binding.submitCharity, binding.submitAll)
         numberstatus.getShowNumberStatus(this)
     }
 

--- a/app/src/main/java/ir/kindnesswall/view/main/catalog/cataloglist/CatalogFragment.kt
+++ b/app/src/main/java/ir/kindnesswall/view/main/catalog/cataloglist/CatalogFragment.kt
@@ -1,7 +1,6 @@
 package ir.kindnesswall.view.main.catalog.cataloglist
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -23,9 +22,7 @@ import ir.kindnesswall.utils.widgets.NoInternetDialogFragment
 import ir.kindnesswall.view.giftdetail.GiftDetailActivity
 import ir.kindnesswall.view.main.addproduct.ReminderSubmitGiftFragment
 import ir.kindnesswall.view.main.addproduct.SubmitGiftActivity
-import kotlinx.android.synthetic.main.toolbar_action_button_layout.*
 import org.koin.android.viewmodel.ext.android.viewModel
-
 
 /**
  * Created by farshid.abazari since 2019-11-07
@@ -69,7 +66,7 @@ class CatalogFragment : BaseFragment(), OnItemClickListener {
                 .navigate(CatalogFragmentDirections.actionCatalogFragmentToSearchFragment())
         }
 
-        actionButton.setOnClickListener {
+        binding.includeToolbarAction.actionButton.setOnClickListener {
             requireContext().runOrStartAuth {
                 SubmitGiftActivity.start(requireContext())
             }

--- a/app/src/main/java/ir/kindnesswall/view/main/charity/CharityFragment.kt
+++ b/app/src/main/java/ir/kindnesswall/view/main/charity/CharityFragment.kt
@@ -16,7 +16,6 @@ import ir.kindnesswall.utils.OnItemClickListener
 import ir.kindnesswall.utils.widgets.NoInternetDialogFragment
 import ir.kindnesswall.view.main.charity.add.AddCharityFragment
 import ir.kindnesswall.view.main.charity.charitydetail.CharityDetailActivity
-import kotlinx.android.synthetic.main.toolbar_action_button_layout.*
 import org.koin.android.viewmodel.ext.android.viewModel
 
 
@@ -56,7 +55,7 @@ class CharityFragment : BaseFragment(), OnItemClickListener {
     }
 
     override fun configureViews() {
-        actionButton.setOnClickListener {
+        binding.includeToolbarAction.actionButton.setOnClickListener {
             val addCharityFragment = AddCharityFragment()
             addCharityFragment.show(childFragmentManager, addCharityFragment.tag)
         }

--- a/app/src/main/java/ir/kindnesswall/view/main/charity/Rating/RatingActivity.kt
+++ b/app/src/main/java/ir/kindnesswall/view/main/charity/Rating/RatingActivity.kt
@@ -1,18 +1,12 @@
 package ir.kindnesswall.view.main.charity.Rating
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.ViewModel
-import androidx.recyclerview.widget.GridLayoutManager
 import ir.kindnesswall.R
 import ir.kindnesswall.data.model.RateModel
 import ir.kindnesswall.databinding.ActivityRatingBinding
-import ir.kindnesswall.view.main.charity.charitydetail.CharityViewModel
-import kotlinx.android.synthetic.main.activity_rating.*
-import org.koin.android.viewmodel.ext.android.viewModel
 
 class RatingActivity : AppCompatActivity() , RateViewListener {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,8 +27,8 @@ class RatingActivity : AppCompatActivity() , RateViewListener {
         list.add(RateModel("C","","",1.5f))
         list.add(RateModel("D","","",1.5f))
         var ratAdapter = RateAdapter(list!!)
-        recycler_rate.adapter = ratAdapter
-        recycler_rate.setNestedScrollingEnabled(false)
+        binding.recyclerRate.adapter = ratAdapter
+        binding.recyclerRate.setNestedScrollingEnabled(false)
 
     }
 

--- a/app/src/main/java/ir/kindnesswall/view/main/more/MoreFragment.kt
+++ b/app/src/main/java/ir/kindnesswall/view/main/more/MoreFragment.kt
@@ -9,9 +9,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.databinding.DataBindingUtil
-import androidx.databinding.Observable
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import androidx.lifecycle.observe
@@ -32,11 +30,7 @@ import ir.kindnesswall.view.main.more.aboutus.AboutUsActivity
 import ir.kindnesswall.view.profile.UserProfileActivity
 import ir.kindnesswall.view.profile.blocklist.BlockListActivity
 import ir.kindnesswall.view.reviewgift.ReviewGiftsActivity
-import kotlinx.android.synthetic.main.activity_submit_gift.*
-import kotlinx.android.synthetic.main.fragment_more.*
-import kotlinx.android.synthetic.main.fragment_more.view.*
 import org.koin.android.viewmodel.ext.android.viewModel
-
 
 /**
  * Created by farshid.abazari since 2019-11-07
@@ -66,7 +60,7 @@ class MoreFragment() : BaseFragment() {
             shPref= context!!.getSharedPreferences(UserInfoPref.MyPref, Context.MODE_PRIVATE)
             sEdite =shPref!!.edit()
            if (UserInfoPref.bearerToken.isNotEmpty()){
-                val numberstatus = NumberStatus(viewModel ,more_none , more_charity , more_all )
+               val numberstatus = NumberStatus(viewModel, binding.moreNone, binding.moreCharity, binding.moreAll)
                 numberstatus.getShowNumberStatus(binding.root.context)
            }
 
@@ -166,13 +160,13 @@ class MoreFragment() : BaseFragment() {
         if (shPref.contains(keyName)) {
             when (shPref.getString(keyName, null)) {
                 "none" -> {
-                    more_none.isChecked = true
+                    binding.moreNone.isChecked = true
                 }
                 "charity" -> {
-                    more_charity.isChecked = true
+                    binding.moreCharity.isChecked = true
                 }
                 "all" -> {
-                    more_all.isChecked = true
+                    binding.moreAll.isChecked = true
                 }
             }
         }

--- a/app/src/main/java/ir/kindnesswall/view/main/more/aboutus/AboutUsActivity.kt
+++ b/app/src/main/java/ir/kindnesswall/view/main/more/aboutus/AboutUsActivity.kt
@@ -3,9 +3,9 @@ package ir.kindnesswall.view.main.more.aboutus
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import ir.kindnesswall.R
-import kotlinx.android.synthetic.main.activity_about_us.*
 
 class AboutUsActivity : AppCompatActivity() {
 
@@ -19,6 +19,6 @@ class AboutUsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_about_us)
 
-        backImageView.setOnClickListener { onBackPressed() }
+        findViewById<View>(R.id.backImageView).setOnClickListener { onBackPressed() }
     }
 }

--- a/app/src/main/res/layout/fragment_catalog.xml
+++ b/app/src/main/res/layout/fragment_catalog.xml
@@ -28,6 +28,7 @@
                 android:textSize="16sp" />
 
             <include
+                android:id="@+id/include_toolbar_action"
                 layout="@layout/toolbar_action_button_layout"
                 app:actionName="@{@string/submit_gift}" />
 

--- a/app/src/main/res/layout/fragment_charity.xml
+++ b/app/src/main/res/layout/fragment_charity.xml
@@ -41,6 +41,7 @@
                 app:srcCompat="@drawable/ic_add_white" />
 
             <include
+                android:id="@+id/include_toolbar_action"
                 layout="@layout/toolbar_action_button_layout"
                 app:actionName="@{@string/submit_charity}" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+apply from: './scripts/dependency_update.gradle'
+
 buildscript {
     ext.kotlin_version = '1.3.61'
     repositories {
@@ -7,6 +9,7 @@ buildscript {
             url 'https://maven.fabric.io/public'
         }
         maven { url 'https://plugins.gradle.org/m2/' }
+        gradlePluginPortal()
 
     }
     dependencies {
@@ -18,6 +21,7 @@ buildscript {
 
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.1'
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.39.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
 
         classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
 
         classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
 
         classpath 'com.google.gms:google-services:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 apply from: './scripts/dependency_update.gradle'
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()
@@ -14,9 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
 
         classpath 'com.google.gms:google-services:4.3.3'

--- a/scripts/dependency_update.gradle
+++ b/scripts/dependency_update.gradle
@@ -1,0 +1,21 @@
+// to get report about all dependencies update
+// run ./gradlew dependencyUpdate
+// more info: https://github.com/ben-manes/gradle-versions-plugin
+
+apply plugin: "com.github.ben-manes.versions"
+
+def isNonStable = { String version ->
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+    def regex = /^[0-9,.v-]+(-r)?$/
+    return !stableKeyword && !(version ==~ regex)
+}
+
+tasks.named("dependencyUpdates").configure {
+    gradleReleaseChannel = "current"
+    outputFormatter = "text"
+    revision = "release"
+    outputDir = "./scripts/dependencyUpdates"
+    rejectVersionIf {
+        isNonStable(it.candidate.version)
+    }
+}

--- a/scripts/extract_dependencies/ExtractDependencies.kts
+++ b/scripts/extract_dependencies/ExtractDependencies.kts
@@ -15,6 +15,7 @@ requiredConfigurations
     }
 
 // https://github.com/ProtonMail/proton-mail-android/blob/977215963d52c989a93a58d3e637b5e8a6124682/scripts/extract_dependencies/ExtractDeps.kts#L217
+@Suppress("UndocumentedPublicFunction")
 fun String.runCommand(workingDir: File = File("./")) {
     val parts = split(" > ")
     ProcessBuilder(parts[0].split("\\s".toRegex()))

--- a/scripts/extract_dependencies/ExtractDependencies.kts
+++ b/scripts/extract_dependencies/ExtractDependencies.kts
@@ -1,0 +1,28 @@
+import java.io.File
+import java.lang.ProcessBuilder.Redirect
+import java.util.concurrent.TimeUnit
+
+val requiredConfigurations = listOf(
+    "kapt",
+    "stagingDebugRuntimeClasspath"
+)
+
+requiredConfigurations
+    .map { configuration ->
+        "./gradlew :app:dependencies --configuration $configuration > scripts/extract_dependencies/$configuration.txt"
+    }.forEach { command ->
+        command.runCommand()
+    }
+
+// https://github.com/ProtonMail/proton-mail-android/blob/977215963d52c989a93a58d3e637b5e8a6124682/scripts/extract_dependencies/ExtractDeps.kts#L217
+fun String.runCommand(workingDir: File = File("./")) {
+    val parts = split(" > ")
+    ProcessBuilder(parts[0].split("\\s".toRegex()))
+        .directory(workingDir).apply {
+            if (parts.size > 1) redirectOutput(File(parts[1]))
+            else redirectOutput(Redirect.INHERIT)
+        }
+        .redirectError(Redirect.INHERIT)
+        .start()
+        .waitFor(10, TimeUnit.MINUTES)
+}

--- a/scripts/extract_dependencies/kapt.txt
+++ b/scripts/extract_dependencies/kapt.txt
@@ -1,0 +1,97 @@
+
+> Configure project :app
+WARNING: DSL element 'android.dataBinding.enabled' is obsolete and has been replaced with 'android.buildFeatures.dataBinding'.
+It will be removed in version 5.0 of the Android Gradle plugin.
+WARNING: API 'BaseVariant.getApplicationIdTextResource' is obsolete and has been replaced with 'VariantProperties.applicationId'.
+It will be removed in version 5.0 of the Android Gradle plugin.
+For more information, see TBD.
+To determine what is calling BaseVariant.getApplicationIdTextResource, use -Pandroid.debug.obsoleteApi=true on the command line to display more information.
+
+> Task :app:dependencies
+
+------------------------------------------------------------
+Project :app
+------------------------------------------------------------
+
+kapt
++--- androidx.room:room-compiler:2.2.5
+|    +--- androidx.room:room-common:2.2.5
+|    |    \--- androidx.annotation:annotation:1.1.0
+|    +--- androidx.room:room-migration:2.2.5
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.3.72
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
+|    |    |    \--- org.jetbrains:annotations:13.0
+|    |    +--- com.google.code.gson:gson:2.8.0 -> 2.8.5
+|    |    \--- androidx.room:room-common:2.2.5 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.3.72 (*)
+|    +--- com.google.auto:auto-common:0.10
+|    |    \--- com.google.guava:guava:23.5-jre -> 28.1-jre
+|    |         +--- com.google.guava:failureaccess:1.0.1
+|    |         +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         +--- org.checkerframework:checker-qual:2.8.1
+|    |         +--- com.google.errorprone:error_prone_annotations:2.3.2
+|    |         +--- com.google.j2objc:j2objc-annotations:1.3
+|    |         \--- org.codehaus.mojo:animal-sniffer-annotations:1.18
+|    +--- com.google.auto.value:auto-value-annotations:1.6.3
+|    +--- com.squareup:javapoet:1.8.0 -> 1.10.0
+|    +--- org.antlr:antlr4:4.7.1
+|    |    +--- org.antlr:antlr4-runtime:4.7.1
+|    |    +--- org.antlr:antlr-runtime:3.5.2
+|    |    +--- org.antlr:ST4:4.0.8
+|    |    |    \--- org.antlr:antlr-runtime:3.5.2
+|    |    +--- org.abego.treelayout:org.abego.treelayout.core:1.0.3
+|    |    +--- org.glassfish:javax.json:1.0.4
+|    |    \--- com.ibm.icu:icu4j:58.2
+|    +--- org.xerial:sqlite-jdbc:3.25.2
+|    +--- org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.0.5
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.11 -> 1.3.72 (*)
+|    \--- commons-codec:commons-codec:1.10
++--- androidx.lifecycle:lifecycle-compiler:2.2.0
+|    +--- androidx.lifecycle:lifecycle-common:2.2.0
+|    |    \--- androidx.annotation:annotation:1.1.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    +--- com.google.auto:auto-common:0.10 (*)
+|    \--- com.squareup:javapoet:1.8.0 -> 1.10.0
++--- com.github.bumptech.glide:compiler:4.10.0
+|    \--- com.github.bumptech.glide:annotations:4.10.0
+\--- androidx.databinding:databinding-compiler:4.1.3
+     +--- androidx.databinding:databinding-compiler-common:4.1.3
+     |    +--- androidx.databinding:databinding-common:4.1.3
+     |    +--- com.android.databinding:baseLibrary:4.1.3
+     |    +--- org.antlr:antlr4:4.5.3 -> 4.7.1 (*)
+     |    +--- commons-io:commons-io:2.4
+     |    +--- com.googlecode.juniversalchardet:juniversalchardet:1.0.3
+     |    +--- com.google.guava:guava:28.1-jre (*)
+     |    +--- com.squareup:javapoet:1.10.0
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72
+     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
+     |    +--- com.google.code.gson:gson:2.8.5
+     |    +--- org.glassfish.jaxb:jaxb-runtime:2.3.1
+     |    |    +--- javax.xml.bind:jaxb-api:2.3.1
+     |    |    |    \--- javax.activation:javax.activation-api:1.2.0
+     |    |    +--- org.glassfish.jaxb:txw2:2.3.1
+     |    |    +--- com.sun.istack:istack-commons-runtime:3.0.7
+     |    |    +--- org.jvnet.staxex:stax-ex:1.8
+     |    |    +--- com.sun.xml.fastinfoset:FastInfoset:1.2.15
+     |    |    \--- javax.activation:javax.activation-api:1.2.0
+     |    +--- com.android.tools:annotations:27.1.3
+     |    \--- com.android.tools.build.jetifier:jetifier-core:1.0.0-beta09
+     |         +--- com.google.code.gson:gson:2.8.0 -> 2.8.5
+     |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+     +--- androidx.databinding:databinding-common:4.1.3
+     +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72 (*)
+     +--- com.google.auto:auto-common:0.10 (*)
+     +--- commons-io:commons-io:2.4
+     +--- commons-codec:commons-codec:1.10
+     +--- org.antlr:antlr4:4.5.3 -> 4.7.1 (*)
+     \--- com.googlecode.juniversalchardet:juniversalchardet:1.0.3
+
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+BUILD SUCCESSFUL in 1s
+1 actionable task: 1 executed

--- a/scripts/extract_dependencies/kapt.txt
+++ b/scripts/extract_dependencies/kapt.txt
@@ -14,60 +14,65 @@ Project :app
 ------------------------------------------------------------
 
 kapt
-+--- androidx.room:room-compiler:2.2.5
-|    +--- androidx.room:room-common:2.2.5
++--- androidx.room:room-compiler:2.3.0
+|    +--- androidx.room:room-common:2.3.0
 |    |    \--- androidx.annotation:annotation:1.1.0
-|    +--- androidx.room:room-migration:2.2.5
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.3.72
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
+|    +--- androidx.room:room-migration:2.3.0
+|    |    +--- androidx.room:room-common:2.3.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.31
 |    |    |    \--- org.jetbrains:annotations:13.0
-|    |    +--- com.google.code.gson:gson:2.8.0 -> 2.8.5
-|    |    \--- androidx.room:room-common:2.2.5 (*)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.3.72 (*)
-|    +--- com.google.auto:auto-common:0.10
-|    |    \--- com.google.guava:guava:23.5-jre -> 28.1-jre
-|    |         +--- com.google.guava:failureaccess:1.0.1
-|    |         +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-|    |         +--- com.google.code.findbugs:jsr305:3.0.2
-|    |         +--- org.checkerframework:checker-qual:2.8.1
-|    |         +--- com.google.errorprone:error_prone_annotations:2.3.2
-|    |         +--- com.google.j2objc:j2objc-annotations:1.3
-|    |         \--- org.codehaus.mojo:animal-sniffer-annotations:1.18
+|    |    \--- com.google.code.gson:gson:2.8.0 -> 2.8.5
+|    +--- androidx.room:room-compiler-processing:2.3.0
+|    |    +--- androidx.annotation:annotation:1.1.0
+|    |    +--- com.google.guava:guava:29.0-jre
+|    |    |    +--- com.google.guava:failureaccess:1.0.1
+|    |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    |    +--- org.checkerframework:checker-qual:2.11.1
+|    |    |    +--- com.google.errorprone:error_prone_annotations:2.3.4
+|    |    |    \--- com.google.j2objc:j2objc-annotations:1.3
+|    |    +--- com.google.auto:auto-common:0.10
+|    |    |    \--- com.google.guava:guava:23.5-jre -> 29.0-jre (*)
+|    |    +--- com.google.auto.value:auto-value-annotations:1.6.3
+|    |    +--- org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.2.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.10 -> 1.4.31 (*)
+|    |    +--- com.intellij:annotations:12.0
+|    |    +--- com.google.devtools.ksp:symbol-processing-api:1.4.30-1.0.0-alpha04
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.30 -> 1.4.31
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.31 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 (*)
+|    |    \--- com.squareup:javapoet:1.13.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 (*)
+|    +--- com.google.auto:auto-common:0.10 (*)
 |    +--- com.google.auto.value:auto-value-annotations:1.6.3
-|    +--- com.squareup:javapoet:1.8.0 -> 1.10.0
-|    +--- org.antlr:antlr4:4.7.1
-|    |    +--- org.antlr:antlr4-runtime:4.7.1
-|    |    +--- org.antlr:antlr-runtime:3.5.2
-|    |    +--- org.antlr:ST4:4.0.8
-|    |    |    \--- org.antlr:antlr-runtime:3.5.2
-|    |    +--- org.abego.treelayout:org.abego.treelayout.core:1.0.3
-|    |    +--- org.glassfish:javax.json:1.0.4
-|    |    \--- com.ibm.icu:icu4j:58.2
+|    +--- com.squareup:javapoet:1.13.0
+|    +--- com.google.devtools.ksp:symbol-processing-api:1.4.30-1.0.0-alpha04 (*)
 |    +--- org.xerial:sqlite-jdbc:3.25.2
-|    +--- org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.0.5
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.11 -> 1.3.72 (*)
-|    \--- commons-codec:commons-codec:1.10
+|    +--- org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.2.0 (*)
+|    +--- commons-codec:commons-codec:1.10
+|    \--- com.intellij:annotations:12.0
 +--- androidx.lifecycle:lifecycle-compiler:2.2.0
 |    +--- androidx.lifecycle:lifecycle-common:2.2.0
 |    |    \--- androidx.annotation:annotation:1.1.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.31 (*)
 |    +--- com.google.auto:auto-common:0.10 (*)
-|    \--- com.squareup:javapoet:1.8.0 -> 1.10.0
+|    \--- com.squareup:javapoet:1.8.0 -> 1.13.0
 +--- com.github.bumptech.glide:compiler:4.10.0
 |    \--- com.github.bumptech.glide:annotations:4.10.0
 \--- androidx.databinding:databinding-compiler:4.1.3
      +--- androidx.databinding:databinding-compiler-common:4.1.3
      |    +--- androidx.databinding:databinding-common:4.1.3
      |    +--- com.android.databinding:baseLibrary:4.1.3
-     |    +--- org.antlr:antlr4:4.5.3 -> 4.7.1 (*)
+     |    +--- org.antlr:antlr4:4.5.3
      |    +--- commons-io:commons-io:2.4
      |    +--- com.googlecode.juniversalchardet:juniversalchardet:1.0.3
-     |    +--- com.google.guava:guava:28.1-jre (*)
-     |    +--- com.squareup:javapoet:1.10.0
-     |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72
-     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
-     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72
-     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
+     |    +--- com.google.guava:guava:28.1-jre -> 29.0-jre (*)
+     |    +--- com.squareup:javapoet:1.10.0 -> 1.13.0
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72 -> 1.4.31 (*)
      |    +--- com.google.code.gson:gson:2.8.5
      |    +--- org.glassfish.jaxb:jaxb-runtime:2.3.1
      |    |    +--- javax.xml.bind:jaxb-api:2.3.1
@@ -80,18 +85,18 @@ kapt
      |    +--- com.android.tools:annotations:27.1.3
      |    \--- com.android.tools.build.jetifier:jetifier-core:1.0.0-beta09
      |         +--- com.google.code.gson:gson:2.8.0 -> 2.8.5
-     |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+     |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.31 (*)
      +--- androidx.databinding:databinding-common:4.1.3
-     +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72 -> 1.4.31 (*)
      +--- com.google.auto:auto-common:0.10 (*)
      +--- commons-io:commons-io:2.4
      +--- commons-codec:commons-codec:1.10
-     +--- org.antlr:antlr4:4.5.3 -> 4.7.1 (*)
+     +--- org.antlr:antlr4:4.5.3
      \--- com.googlecode.juniversalchardet:juniversalchardet:1.0.3
 
 (*) - dependencies omitted (listed previously)
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 1s
+BUILD SUCCESSFUL in 2s
 1 actionable task: 1 executed

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -30,13 +30,14 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- androidx.databinding:databinding-adapters:4.1.3
 |    +--- androidx.databinding:databinding-common:4.1.3
 |    \--- androidx.databinding:databinding-runtime:4.1.3 (*)
++--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
+|    \--- org.jetbrains:annotations:13.0
 +--- com.github.chuckerteam.chucker:library:3.2.0
 |    +--- androidx.databinding:viewbinding:3.6.1 -> 4.1.3 (*)
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.3.72
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72
-|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
-|    |         \--- org.jetbrains:annotations:13.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
 |    +--- com.google.android.material:material:1.1.0
 |    |    +--- androidx.annotation:annotation:1.0.1 -> 1.1.0
 |    |    +--- androidx.appcompat:appcompat:1.1.0
@@ -140,22 +141,22 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- androidx.constraintlayout:constraintlayout:1.1.3
 |    |    \--- androidx.constraintlayout:constraintlayout-solver:1.1.3
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.3.72 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.0 (*)
 |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5
-|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.3.72 (*)
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.3.72
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.0 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.4.0
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    +--- androidx.lifecycle:lifecycle-livedata:2.3.0-alpha01 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.3.0-alpha01
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.0 (*)
 |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.3.5 (*)
 |    +--- androidx.room:room-ktx:2.2.5
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.3.72 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
 |    |    +--- androidx.room:room-common:2.2.5
 |    |    |    \--- androidx.annotation:annotation:1.1.0
@@ -173,7 +174,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- com.google.code.gson:gson:2.8.6
 |    \--- com.squareup.okhttp3:okhttp:3.12.10
 |         \--- com.squareup.okio:okio:1.15.0
-+--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.61 -> 1.3.72 (*)
++--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.0 (*)
 +--- androidx.appcompat:appcompat:1.1.0 (*)
 +--- androidx.cardview:cardview:1.0.0 (*)
 +--- androidx.recyclerview:recyclerview:1.1.0 (*)
@@ -181,21 +182,11 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- androidx.constraintlayout:constraintlayout:1.1.3 (*)
 +--- androidx.room:room-runtime:2.2.5 (*)
 +--- androidx.room:room-ktx:2.2.5 (*)
-+--- org.jetbrains.kotlin:kotlin-stdlib:1.3.61 -> 1.3.72 (*)
-+--- org.jetbrains.kotlin:kotlin-test-junit:1.3.61
-|    +--- org.jetbrains.kotlin:kotlin-test-annotations-common:1.3.61
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61 -> 1.3.72
-|    +--- org.jetbrains.kotlin:kotlin-test:1.3.61
-|    |    +--- org.jetbrains.kotlin:kotlin-test-common:1.3.61
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61 -> 1.3.72
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.61 -> 1.3.72 (*)
-|    \--- junit:junit:4.12
-|         \--- org.hamcrest:hamcrest-core:1.3
 +--- org.koin:koin-android-viewmodel:2.0.1
 |    +--- org.koin:koin-android-scope:2.0.1
 |    |    +--- org.koin:koin-android:2.0.1
 |    |    |    \--- org.koin:koin-core:2.0.1
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.3.72 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.4.0 (*)
 |    |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.0-alpha01 (*)
 |    \--- androidx.lifecycle:lifecycle-extensions:2.0.0 -> 2.2.0
@@ -229,36 +220,36 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
 |    |    +--- androidx.navigation:navigation-common-ktx:2.3.5
 |    |    |    +--- androidx.navigation:navigation-common:2.3.5 (*)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
 |    |    |    |    +--- androidx.annotation:annotation:1.1.0
 |    |    |    |    \--- androidx.core:core:1.3.0 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.0 (*)
 |    |    |    +--- androidx.activity:activity:1.1.0 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0-alpha01 (*)
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.0 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
 |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
 |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
 |    +--- androidx.fragment:fragment-ktx:1.2.4
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.0 (*)
 |    |    +--- androidx.fragment:fragment:1.2.4 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0 (*)
 |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    +--- androidx.collection:collection-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.3.72 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.4.0 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.2.0 -> 2.3.0-alpha01 (*)
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
 +--- androidx.navigation:navigation-ui-ktx:2.3.5
 |    +--- androidx.navigation:navigation-ui:2.3.5
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
@@ -267,7 +258,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- com.google.android.material:material:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.transition:transition:1.3.0 (*)
 |    +--- androidx.navigation:navigation-runtime-ktx:2.3.5 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
 +--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
 +--- androidx.legacy:legacy-support-v4:1.0.0
 |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
@@ -445,7 +436,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 +--- com.ryanjeffreybrooks:indefinitepagerindicator:1.0.10
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41 -> 1.3.72
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.0 (*)
 |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    \--- androidx.recyclerview:recyclerview:1.0.0 -> 1.1.0 (*)
 +--- androidx.browser:browser:1.2.0
@@ -459,11 +450,11 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.interpolator:interpolator:1.0.0 (*)
 +--- com.github.marlonlom:timeago:4.0.3
 +--- net.gotev:uploadservice:4.3.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.3.72 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.0 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71 -> 1.3.72 (*)
 +--- com.github.nguyenhoanglam:ImagePicker:1.4.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.4.0 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    +--- androidx.recyclerview:recyclerview:1.1.0 (*)
 |    +--- com.google.android.material:material:1.1.0 (*)
@@ -476,8 +467,8 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- it.xabaras.android:recyclerview-swipedecorator:1.2.2
 +--- com.github.samanzamani.persiandate:PersianDate:0.8
 \--- project :spotlight
-     +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.61 -> 1.3.72 (*)
-     +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.61 -> 1.3.72 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
+     +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.0 (*)
      +--- androidx.core:core-ktx:1.3.0 (*)
      \--- androidx.appcompat:appcompat:1.1.0 (*)
 
@@ -485,5 +476,5 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 918ms
+BUILD SUCCESSFUL in 3s
 1 actionable task: 1 executed

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -30,14 +30,14 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- androidx.databinding:databinding-adapters:4.1.3
 |    +--- androidx.databinding:databinding-common:4.1.3
 |    \--- androidx.databinding:databinding-runtime:4.1.3 (*)
-+--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
++--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20
 |    \--- org.jetbrains:annotations:13.0
 +--- com.github.chuckerteam.chucker:library:3.2.0
 |    +--- androidx.databinding:viewbinding:3.6.1 -> 4.1.3 (*)
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.0
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.20
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
 |    +--- com.google.android.material:material:1.1.0
 |    |    +--- androidx.annotation:annotation:1.0.1 -> 1.1.0
 |    |    +--- androidx.appcompat:appcompat:1.1.0
@@ -141,22 +141,22 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- androidx.constraintlayout:constraintlayout:1.1.3
 |    |    \--- androidx.constraintlayout:constraintlayout-solver:1.1.3
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.20 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.20 (*)
 |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5
-|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.0 (*)
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.4.0
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.20 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.4.20
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    +--- androidx.lifecycle:lifecycle-livedata:2.3.0-alpha01 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.3.0-alpha01
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.0 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.20 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.20 (*)
 |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.3.5 (*)
 |    +--- androidx.room:room-ktx:2.2.5
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.20 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
 |    |    +--- androidx.room:room-common:2.2.5
 |    |    |    \--- androidx.annotation:annotation:1.1.0
@@ -174,7 +174,9 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- com.google.code.gson:gson:2.8.6
 |    \--- com.squareup.okhttp3:okhttp:3.12.10
 |         \--- com.squareup.okio:okio:1.15.0
-+--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.0 (*)
++--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.4.20
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20 (*)
+|    \--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.20 (*)
 +--- androidx.appcompat:appcompat:1.1.0 (*)
 +--- androidx.cardview:cardview:1.0.0 (*)
 +--- androidx.recyclerview:recyclerview:1.1.0 (*)
@@ -186,7 +188,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- org.koin:koin-android-scope:2.0.1
 |    |    +--- org.koin:koin-android:2.0.1
 |    |    |    \--- org.koin:koin-core:2.0.1
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.4.0 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.4.20 (*)
 |    |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.0-alpha01 (*)
 |    \--- androidx.lifecycle:lifecycle-extensions:2.0.0 -> 2.2.0
@@ -220,36 +222,36 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
 |    |    +--- androidx.navigation:navigation-common-ktx:2.3.5
 |    |    |    +--- androidx.navigation:navigation-common:2.3.5 (*)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
 |    |    |    |    +--- androidx.annotation:annotation:1.1.0
 |    |    |    |    \--- androidx.core:core:1.3.0 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.20 (*)
 |    |    |    +--- androidx.activity:activity:1.1.0 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0-alpha01 (*)
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.20 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
 |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
 |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
 |    +--- androidx.fragment:fragment-ktx:1.2.4
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.20 (*)
 |    |    +--- androidx.fragment:fragment:1.2.4 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0 (*)
 |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    +--- androidx.collection:collection-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.4.20 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.2.0 -> 2.3.0-alpha01 (*)
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
 +--- androidx.navigation:navigation-ui-ktx:2.3.5
 |    +--- androidx.navigation:navigation-ui:2.3.5
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
@@ -258,7 +260,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- com.google.android.material:material:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.transition:transition:1.3.0 (*)
 |    +--- androidx.navigation:navigation-runtime-ktx:2.3.5 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
 +--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
 +--- androidx.legacy:legacy-support-v4:1.0.0
 |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
@@ -436,7 +438,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 +--- com.ryanjeffreybrooks:indefinitepagerindicator:1.0.10
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41 -> 1.3.72
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.20 (*)
 |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    \--- androidx.recyclerview:recyclerview:1.0.0 -> 1.1.0 (*)
 +--- androidx.browser:browser:1.2.0
@@ -450,11 +452,11 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.interpolator:interpolator:1.0.0 (*)
 +--- com.github.marlonlom:timeago:4.0.3
 +--- net.gotev:uploadservice:4.3.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.20 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71 -> 1.3.72 (*)
 +--- com.github.nguyenhoanglam:ImagePicker:1.4.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.4.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.4.20 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    +--- androidx.recyclerview:recyclerview:1.1.0 (*)
 |    +--- com.google.android.material:material:1.1.0 (*)
@@ -467,8 +469,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- it.xabaras.android:recyclerview-swipedecorator:1.2.2
 +--- com.github.samanzamani.persiandate:PersianDate:0.8
 \--- project :spotlight
-     +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-     +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.0 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20 (*)
      +--- androidx.core:core-ktx:1.3.0 (*)
      \--- androidx.appcompat:appcompat:1.1.0 (*)
 
@@ -476,5 +477,5 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 3s
+BUILD SUCCESSFUL in 2s
 1 actionable task: 1 executed

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -30,14 +30,14 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- androidx.databinding:databinding-adapters:4.1.3
 |    +--- androidx.databinding:databinding-common:4.1.3
 |    \--- androidx.databinding:databinding-runtime:4.1.3 (*)
-+--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20
++--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.32
 |    \--- org.jetbrains:annotations:13.0
 +--- com.github.chuckerteam.chucker:library:3.2.0
 |    +--- androidx.databinding:viewbinding:3.6.1 -> 4.1.3 (*)
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.20
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20 (*)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.32
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
 |    +--- com.google.android.material:material:1.1.0
 |    |    +--- androidx.annotation:annotation:1.0.1 -> 1.1.0
 |    |    +--- androidx.appcompat:appcompat:1.1.0
@@ -141,22 +141,22 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- androidx.constraintlayout:constraintlayout:1.1.3
 |    |    \--- androidx.constraintlayout:constraintlayout-solver:1.1.3
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.20 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.20 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.32 (*)
 |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5
-|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.20 (*)
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.4.20
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.32 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.4.32
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    +--- androidx.lifecycle:lifecycle-livedata:2.3.0-alpha01 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.3.0-alpha01
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.20 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.20 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
 |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.3.5 (*)
 |    +--- androidx.room:room-ktx:2.2.5
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.20 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.32 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
 |    |    +--- androidx.room:room-common:2.2.5
 |    |    |    \--- androidx.annotation:annotation:1.1.0
@@ -174,9 +174,9 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- com.google.code.gson:gson:2.8.6
 |    \--- com.squareup.okhttp3:okhttp:3.12.10
 |         \--- com.squareup.okio:okio:1.15.0
-+--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.4.20
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20 (*)
-|    \--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.20 (*)
++--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.4.32
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32 (*)
+|    \--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.32 (*)
 +--- androidx.appcompat:appcompat:1.1.0 (*)
 +--- androidx.cardview:cardview:1.0.0 (*)
 +--- androidx.recyclerview:recyclerview:1.1.0 (*)
@@ -188,7 +188,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- org.koin:koin-android-scope:2.0.1
 |    |    +--- org.koin:koin-android:2.0.1
 |    |    |    \--- org.koin:koin-core:2.0.1
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.4.20 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.4.32 (*)
 |    |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.0-alpha01 (*)
 |    \--- androidx.lifecycle:lifecycle-extensions:2.0.0 -> 2.2.0
@@ -222,36 +222,36 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
 |    |    +--- androidx.navigation:navigation-common-ktx:2.3.5
 |    |    |    +--- androidx.navigation:navigation-common:2.3.5 (*)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
 |    |    |    |    +--- androidx.annotation:annotation:1.1.0
 |    |    |    |    \--- androidx.core:core:1.3.0 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.20 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
 |    |    |    +--- androidx.activity:activity:1.1.0 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0-alpha01 (*)
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.20 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
 |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
 |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
 |    +--- androidx.fragment:fragment-ktx:1.2.4
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.20 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
 |    |    +--- androidx.fragment:fragment:1.2.4 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0 (*)
 |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    +--- androidx.collection:collection-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.4.20 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.4.32 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.2.0 -> 2.3.0-alpha01 (*)
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
 +--- androidx.navigation:navigation-ui-ktx:2.3.5
 |    +--- androidx.navigation:navigation-ui:2.3.5
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
@@ -260,7 +260,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- com.google.android.material:material:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.transition:transition:1.3.0 (*)
 |    +--- androidx.navigation:navigation-runtime-ktx:2.3.5 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.20 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
 +--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
 +--- androidx.legacy:legacy-support-v4:1.0.0
 |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
@@ -438,7 +438,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 +--- com.ryanjeffreybrooks:indefinitepagerindicator:1.0.10
 |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41 -> 1.3.72
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.20 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.32 (*)
 |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    \--- androidx.recyclerview:recyclerview:1.0.0 -> 1.1.0 (*)
 +--- androidx.browser:browser:1.2.0
@@ -452,11 +452,11 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.interpolator:interpolator:1.0.0 (*)
 +--- com.github.marlonlom:timeago:4.0.3
 +--- net.gotev:uploadservice:4.3.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.20 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.32 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71 -> 1.3.72 (*)
 +--- com.github.nguyenhoanglam:ImagePicker:1.4.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.4.20 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.4.32 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    +--- androidx.recyclerview:recyclerview:1.1.0 (*)
 |    +--- com.google.android.material:material:1.1.0 (*)
@@ -469,7 +469,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- it.xabaras.android:recyclerview-swipedecorator:1.2.2
 +--- com.github.samanzamani.persiandate:PersianDate:0.8
 \--- project :spotlight
-     +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.20 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32 (*)
      +--- androidx.core:core-ktx:1.3.0 (*)
      \--- androidx.appcompat:appcompat:1.1.0 (*)
 
@@ -477,5 +477,5 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 2s
+BUILD SUCCESSFUL in 1s
 1 actionable task: 1 executed

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -1,0 +1,489 @@
+
+> Configure project :app
+WARNING: DSL element 'android.dataBinding.enabled' is obsolete and has been replaced with 'android.buildFeatures.dataBinding'.
+It will be removed in version 5.0 of the Android Gradle plugin.
+WARNING: API 'BaseVariant.getApplicationIdTextResource' is obsolete and has been replaced with 'VariantProperties.applicationId'.
+It will be removed in version 5.0 of the Android Gradle plugin.
+For more information, see TBD.
+To determine what is calling BaseVariant.getApplicationIdTextResource, use -Pandroid.debug.obsoleteApi=true on the command line to display more information.
+
+> Task :app:dependencies
+
+------------------------------------------------------------
+Project :app
+------------------------------------------------------------
+
+stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (target  (androidJvm)).
++--- androidx.databinding:databinding-common:4.1.3
++--- androidx.databinding:databinding-runtime:4.1.3
+|    +--- androidx.databinding:viewbinding:4.1.3
+|    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    +--- androidx.lifecycle:lifecycle-runtime:2.0.0 -> 2.3.0-alpha01
+|    |    +--- androidx.lifecycle:lifecycle-common:2.3.0-alpha01
+|    |    |    \--- androidx.annotation:annotation:1.1.0
+|    |    +--- androidx.arch.core:core-common:2.1.0
+|    |    |    \--- androidx.annotation:annotation:1.1.0
+|    |    \--- androidx.annotation:annotation:1.1.0
+|    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    \--- androidx.annotation:annotation:1.1.0
+|    \--- androidx.databinding:databinding-common:4.1.3
++--- androidx.databinding:databinding-adapters:4.1.3
+|    +--- androidx.databinding:databinding-common:4.1.3
+|    \--- androidx.databinding:databinding-runtime:4.1.3 (*)
++--- com.github.chuckerteam.chucker:library:3.2.0
+|    +--- androidx.databinding:viewbinding:3.6.1 -> 4.1.3 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.3.72
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72
+|    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
+|    |         \--- org.jetbrains:annotations:13.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    +--- com.google.android.material:material:1.1.0
+|    |    +--- androidx.annotation:annotation:1.0.1 -> 1.1.0
+|    |    +--- androidx.appcompat:appcompat:1.1.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.0.0 -> 2.3.0-alpha01 (*)
+|    |    |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.cursoradapter:cursoradapter:1.0.0
+|    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.fragment:fragment:1.1.0 -> 1.2.4
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    +--- androidx.viewpager:viewpager:1.0.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    |    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    |    |    |    \--- androidx.customview:customview:1.0.0 -> 1.1.0
+|    |    |    |    |         +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    |         +--- androidx.core:core:1.3.0 (*)
+|    |    |    |    |         \--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    +--- androidx.loader:loader:1.0.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    |    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0 -> 2.3.0-alpha01
+|    |    |    |    |    |    +--- androidx.arch.core:core-runtime:2.1.0
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    |    |    |    \--- androidx.arch.core:core-common:2.1.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.3.0-alpha01 (*)
+|    |    |    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 (*)
+|    |    |    |    |    |    |    \--- androidx.arch.core:core-runtime:2.1.0 (*)
+|    |    |    |    |    |    \--- androidx.arch.core:core-common:2.1.0 (*)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.2.0
+|    |    |    |    |         \--- androidx.annotation:annotation:1.1.0
+|    |    |    |    +--- androidx.activity:activity:1.1.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.2.0 -> 2.3.0-alpha01 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
+|    |    |    |    |    +--- androidx.savedstate:savedstate:1.0.0
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.0.1 -> 2.1.0 (*)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.0-alpha01 (*)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0 -> 2.2.0
+|    |    |    |    |         +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    |    |         +--- androidx.savedstate:savedstate:1.0.0 (*)
+|    |    |    |    |         +--- androidx.lifecycle:lifecycle-livedata-core:2.2.0 -> 2.3.0-alpha01 (*)
+|    |    |    |    |         \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.2.0 -> 2.3.0-alpha01 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0 (*)
+|    |    |    +--- androidx.appcompat:appcompat-resources:1.1.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    +--- androidx.core:core:1.0.1 -> 1.3.0 (*)
+|    |    |    |    +--- androidx.vectordrawable:vectordrawable:1.1.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    |    |    |    \--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    +--- androidx.vectordrawable:vectordrawable-animated:1.1.0
+|    |    |    |    |    +--- androidx.vectordrawable:vectordrawable:1.1.0 (*)
+|    |    |    |    |    +--- androidx.interpolator:interpolator:1.0.0
+|    |    |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    |    |    \--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.drawerlayout:drawerlayout:1.0.0 -> 1.1.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    +--- androidx.core:core:1.2.0 -> 1.3.0 (*)
+|    |    |    |    \--- androidx.customview:customview:1.1.0 (*)
+|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.cardview:cardview:1.0.0
+|    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    +--- androidx.coordinatorlayout:coordinatorlayout:1.1.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.customview:customview:1.0.0 -> 1.1.0 (*)
+|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    +--- androidx.fragment:fragment:1.0.0 -> 1.2.4 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.0.0 -> 2.3.0-alpha01 (*)
+|    |    +--- androidx.recyclerview:recyclerview:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.customview:customview:1.0.0 -> 1.1.0 (*)
+|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.transition:transition:1.2.0 -> 1.3.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    \--- androidx.lifecycle:lifecycle-runtime:2.2.0 -> 2.3.0-alpha01 (*)
+|    |    +--- androidx.vectordrawable:vectordrawable:1.1.0 (*)
+|    |    \--- androidx.viewpager2:viewpager2:1.0.0
+|    |         +--- androidx.annotation:annotation:1.1.0
+|    |         +--- androidx.fragment:fragment:1.1.0 -> 1.2.4 (*)
+|    |         +--- androidx.recyclerview:recyclerview:1.1.0 (*)
+|    |         +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |         \--- androidx.collection:collection:1.1.0 (*)
+|    +--- androidx.constraintlayout:constraintlayout:1.1.3
+|    |    \--- androidx.constraintlayout:constraintlayout-solver:1.1.3
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.3.72 (*)
+|    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.3.72 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.3.72
+|    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
+|    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.2.0 -> 2.3.0-alpha01
+|    |    +--- androidx.lifecycle:lifecycle-livedata:2.3.0-alpha01 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.3.0-alpha01
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.3.5 (*)
+|    +--- androidx.room:room-ktx:2.2.5
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.3.72 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
+|    |    +--- androidx.room:room-common:2.2.5
+|    |    |    \--- androidx.annotation:annotation:1.1.0
+|    |    \--- androidx.room:room-runtime:2.2.5
+|    |         +--- androidx.room:room-common:2.2.5 (*)
+|    |         +--- androidx.sqlite:sqlite-framework:2.0.1
+|    |         |    +--- androidx.annotation:annotation:1.0.2 -> 1.1.0
+|    |         |    \--- androidx.sqlite:sqlite:2.0.1
+|    |         |         \--- androidx.annotation:annotation:1.0.2 -> 1.1.0
+|    |         +--- androidx.sqlite:sqlite:2.0.1 (*)
+|    |         \--- androidx.arch.core:core-runtime:2.0.1 -> 2.1.0 (*)
+|    +--- androidx.room:room-runtime:2.2.5 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5 (*)
+|    +--- com.google.code.gson:gson:2.8.6
+|    \--- com.squareup.okhttp3:okhttp:3.12.10
+|         \--- com.squareup.okio:okio:1.15.0
++--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.61 -> 1.3.72 (*)
++--- androidx.appcompat:appcompat:1.1.0 (*)
++--- androidx.cardview:cardview:1.0.0 (*)
++--- androidx.recyclerview:recyclerview:1.1.0 (*)
++--- com.google.android:flexbox:2.0.1
++--- androidx.constraintlayout:constraintlayout:1.1.3 (*)
++--- androidx.room:room-runtime:2.2.5 (*)
++--- androidx.room:room-ktx:2.2.5 (*)
++--- org.jetbrains.kotlin:kotlin-stdlib:1.3.61 -> 1.3.72 (*)
++--- org.jetbrains.kotlin:kotlin-test-junit:1.3.61
+|    +--- org.jetbrains.kotlin:kotlin-test-annotations-common:1.3.61
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61 -> 1.3.72
+|    +--- org.jetbrains.kotlin:kotlin-test:1.3.61
+|    |    +--- org.jetbrains.kotlin:kotlin-test-common:1.3.61
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61 -> 1.3.72
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.61 -> 1.3.72 (*)
+|    \--- junit:junit:4.12
+|         \--- org.hamcrest:hamcrest-core:1.3
++--- org.koin:koin-android-viewmodel:2.0.1
+|    +--- org.koin:koin-android-scope:2.0.1
+|    |    +--- org.koin:koin-android:2.0.1
+|    |    |    \--- org.koin:koin-core:2.0.1
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.3.72 (*)
+|    |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
+|    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.0-alpha01 (*)
+|    \--- androidx.lifecycle:lifecycle-extensions:2.0.0 -> 2.2.0
+|         +--- androidx.lifecycle:lifecycle-runtime:2.2.0 -> 2.3.0-alpha01 (*)
+|         +--- androidx.arch.core:core-common:2.1.0 (*)
+|         +--- androidx.arch.core:core-runtime:2.1.0 (*)
+|         +--- androidx.fragment:fragment:1.2.0 -> 1.2.4 (*)
+|         +--- androidx.lifecycle:lifecycle-common:2.2.0 -> 2.3.0-alpha01 (*)
+|         +--- androidx.lifecycle:lifecycle-livedata:2.2.0 -> 2.3.0-alpha01 (*)
+|         +--- androidx.lifecycle:lifecycle-process:2.2.0
+|         |    \--- androidx.lifecycle:lifecycle-runtime:2.2.0 -> 2.3.0-alpha01 (*)
+|         +--- androidx.lifecycle:lifecycle-service:2.2.0
+|         |    \--- androidx.lifecycle:lifecycle-runtime:2.2.0 -> 2.3.0-alpha01 (*)
+|         \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
++--- androidx.annotation:annotation:1.0.1 -> 1.1.0
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1 -> 1.3.5 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1 -> 1.3.5 (*)
++--- androidx.navigation:navigation-fragment-ktx:2.3.5
+|    +--- androidx.navigation:navigation-fragment:2.3.5
+|    |    +--- androidx.fragment:fragment:1.2.4 (*)
+|    |    \--- androidx.navigation:navigation-runtime:2.3.5
+|    |         +--- androidx.navigation:navigation-common:2.3.5
+|    |         |    +--- androidx.annotation:annotation:1.1.0
+|    |         |    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    |         |    \--- androidx.collection:collection:1.1.0 (*)
+|    |         +--- androidx.activity:activity:1.1.0 (*)
+|    |         +--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
+|    |         +--- androidx.savedstate:savedstate:1.0.0 (*)
+|    |         \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0 (*)
+|    +--- androidx.navigation:navigation-runtime-ktx:2.3.5
+|    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
+|    |    +--- androidx.navigation:navigation-common-ktx:2.3.5
+|    |    |    +--- androidx.navigation:navigation-common:2.3.5 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    |    \--- androidx.core:core:1.3.0 (*)
+|    |    |    \--- androidx.collection:collection:1.1.0 (*)
+|    |    +--- androidx.activity:activity-ktx:1.1.0
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    |    |    +--- androidx.activity:activity:1.1.0 (*)
+|    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.2.0 -> 2.3.0-alpha01
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0-alpha01 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.3.72 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
+|    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
+|    +--- androidx.fragment:fragment-ktx:1.2.4
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.3.72 (*)
+|    |    +--- androidx.fragment:fragment:1.2.4 (*)
+|    |    +--- androidx.activity:activity-ktx:1.1.0 (*)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
+|    |    +--- androidx.collection:collection-ktx:1.1.0
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.3.72 (*)
+|    |    |    \--- androidx.collection:collection:1.1.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.2.0 -> 2.3.0-alpha01 (*)
+|    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
++--- androidx.navigation:navigation-ui-ktx:2.3.5
+|    +--- androidx.navigation:navigation-ui:2.3.5
+|    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
+|    |    +--- androidx.customview:customview:1.1.0 (*)
+|    |    +--- androidx.drawerlayout:drawerlayout:1.1.1 (*)
+|    |    +--- com.google.android.material:material:1.0.0 -> 1.1.0 (*)
+|    |    \--- androidx.transition:transition:1.3.0 (*)
+|    +--- androidx.navigation:navigation-runtime-ktx:2.3.5 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.3.72 (*)
++--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
++--- androidx.legacy:legacy-support-v4:1.0.0
+|    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    +--- androidx.media:media:1.0.0
+|    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    \--- androidx.versionedparcelable:versionedparcelable:1.0.0 -> 1.1.0 (*)
+|    +--- androidx.legacy:legacy-support-core-utils:1.0.0
+|    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    +--- androidx.documentfile:documentfile:1.0.0
+|    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    +--- androidx.loader:loader:1.0.0 (*)
+|    |    +--- androidx.localbroadcastmanager:localbroadcastmanager:1.0.0
+|    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    \--- androidx.print:print:1.0.0
+|    |         \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    +--- androidx.legacy:legacy-support-core-ui:1.0.0
+|    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    +--- androidx.legacy:legacy-support-core-utils:1.0.0 (*)
+|    |    +--- androidx.customview:customview:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.viewpager:viewpager:1.0.0 (*)
+|    |    +--- androidx.coordinatorlayout:coordinatorlayout:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.drawerlayout:drawerlayout:1.0.0 -> 1.1.1 (*)
+|    |    +--- androidx.slidingpanelayout:slidingpanelayout:1.0.0
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    |    \--- androidx.customview:customview:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.interpolator:interpolator:1.0.0 (*)
+|    |    +--- androidx.swiperefreshlayout:swiperefreshlayout:1.0.0
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    |    \--- androidx.interpolator:interpolator:1.0.0 (*)
+|    |    +--- androidx.asynclayoutinflater:asynclayoutinflater:1.0.0
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    \--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    \--- androidx.cursoradapter:cursoradapter:1.0.0 (*)
+|    \--- androidx.fragment:fragment:1.0.0 -> 1.2.4 (*)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
++--- androidx.core:core-ktx:1.2.0 -> 1.3.0 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-alpha01 (*)
++--- androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-alpha01 (*)
++--- com.squareup.retrofit2:retrofit:2.6.0
+|    \--- com.squareup.okhttp3:okhttp:3.12.0 -> 3.12.10 (*)
++--- com.squareup.retrofit2:converter-gson:2.6.0
+|    +--- com.squareup.retrofit2:retrofit:2.6.0 (*)
+|    \--- com.google.code.gson:gson:2.8.5 -> 2.8.6
++--- com.squareup.okhttp3:logging-interceptor:3.9.1
+|    \--- com.squareup.okhttp3:okhttp:3.9.1 -> 3.12.10 (*)
++--- com.github.bumptech.glide:glide:4.10.0 -> 4.11.0
+|    +--- com.github.bumptech.glide:gifdecoder:4.11.0
+|    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    +--- com.github.bumptech.glide:disklrucache:4.11.0
+|    +--- com.github.bumptech.glide:annotations:4.11.0
+|    +--- androidx.fragment:fragment:1.0.0 -> 1.2.4 (*)
+|    +--- androidx.vectordrawable:vectordrawable-animated:1.0.0 -> 1.1.0 (*)
+|    \--- androidx.exifinterface:exifinterface:1.0.0
+|         \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
++--- com.google.firebase:firebase-messaging:20.2.0
+|    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    +--- com.google.android.datatransport:transport-api:2.2.0
+|    +--- com.google.android.datatransport:transport-backend-cct:2.2.0 -> 2.2.1
+|    |    +--- androidx.annotation:annotation:1.1.0
+|    |    +--- com.google.android.datatransport:transport-api:2.2.0
+|    |    +--- com.google.android.datatransport:transport-runtime:2.2.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0
+|    |    |    +--- com.google.android.datatransport:transport-api:2.2.0
+|    |    |    \--- com.google.dagger:dagger:2.27
+|    |    |         \--- javax.inject:javax.inject:1
+|    |    \--- com.google.firebase:firebase-encoders-json:16.1.0
+|    |         \--- androidx.annotation:annotation:1.1.0
+|    +--- com.google.android.datatransport:transport-runtime:2.2.0 -> 2.2.1 (*)
+|    +--- com.google.android.gms:play-services-basement:17.0.0
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    \--- androidx.fragment:fragment:1.0.0 -> 1.2.4 (*)
+|    +--- com.google.android.gms:play-services-stats:17.0.0
+|    |    +--- androidx.legacy:legacy-support-core-utils:1.0.0 (*)
+|    |    \--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    +--- com.google.android.gms:play-services-tasks:17.0.0
+|    |    \--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    +--- com.google.firebase:firebase-common:19.3.0
+|    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    |    +--- com.google.auto.value:auto-value-annotations:1.6.5
+|    |    \--- com.google.firebase:firebase-components:16.0.0
+|    |         \--- androidx.annotation:annotation:1.1.0
+|    +--- com.google.firebase:firebase-components:16.0.0 (*)
+|    +--- com.google.firebase:firebase-datatransport:17.0.3
+|    |    +--- androidx.annotation:annotation:1.1.0
+|    |    +--- com.google.android.datatransport:transport-api:2.1.0 -> 2.2.0
+|    |    +--- com.google.android.datatransport:transport-backend-cct:2.1.0 -> 2.2.1 (*)
+|    |    +--- com.google.android.datatransport:transport-runtime:2.1.0 -> 2.2.1 (*)
+|    |    \--- com.google.firebase:firebase-common:19.3.0 (*)
+|    +--- com.google.firebase:firebase-encoders-json:16.0.0 -> 16.1.0 (*)
+|    +--- com.google.firebase:firebase-iid:20.2.0
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    +--- androidx.legacy:legacy-support-core-utils:1.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-stats:17.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    |    +--- com.google.firebase:firebase-common:19.3.0 (*)
+|    |    +--- com.google.firebase:firebase-components:16.0.0 (*)
+|    |    +--- com.google.firebase:firebase-iid-interop:17.0.0
+|    |    |    +--- com.google.android.gms:play-services-base:17.0.0
+|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.2.4 (*)
+|    |    |    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    |    |    \--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    +--- com.google.firebase:firebase-installations:16.3.1
+|    |    |    +--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    |    |    +--- com.google.firebase:firebase-common:19.3.0 (*)
+|    |    |    +--- com.google.firebase:firebase-components:16.0.0 (*)
+|    |    |    \--- com.google.firebase:firebase-installations-interop:16.0.0
+|    |    |         \--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    |    \--- com.google.firebase:firebase-installations-interop:16.0.0 (*)
+|    +--- com.google.firebase:firebase-installations:16.3.1 (*)
+|    +--- com.google.firebase:firebase-installations-interop:16.0.0 (*)
+|    \--- com.google.firebase:firebase-measurement-connector:18.0.0
+|         \--- com.google.android.gms:play-services-basement:17.0.0 (*)
++--- com.google.firebase:firebase-analytics:17.4.2
+|    +--- com.google.android.gms:play-services-measurement:17.4.2
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.legacy:legacy-support-core-utils:1.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-measurement-base:17.4.2
+|    |    |    \--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-measurement-impl:17.4.2
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-ads-identifier:17.0.0
+|    |    |    |    \--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-measurement-base:17.4.2 (*)
+|    |    |    \--- com.google.android.gms:play-services-stats:17.0.0 (*)
+|    |    \--- com.google.android.gms:play-services-stats:17.0.0 (*)
+|    +--- com.google.android.gms:play-services-measurement-api:17.4.2
+|    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    +--- com.google.android.gms:play-services-measurement-base:17.4.2 (*)
+|    |    +--- com.google.android.gms:play-services-measurement-impl:17.4.2 (*)
+|    |    +--- com.google.android.gms:play-services-measurement-sdk-api:17.4.2
+|    |    |    +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-measurement-base:17.4.2 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    |    +--- com.google.firebase:firebase-common:19.3.0 (*)
+|    |    +--- com.google.firebase:firebase-components:16.0.0 (*)
+|    |    +--- com.google.firebase:firebase-iid:20.1.5 -> 20.2.0 (*)
+|    |    \--- com.google.firebase:firebase-measurement-connector:18.0.0 (*)
+|    \--- com.google.android.gms:play-services-measurement-sdk:17.4.2
+|         +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|         +--- com.google.android.gms:play-services-basement:17.0.0 (*)
+|         +--- com.google.android.gms:play-services-measurement-base:17.4.2 (*)
+|         \--- com.google.android.gms:play-services-measurement-impl:17.4.2 (*)
++--- com.google.firebase:firebase-crashlytics:17.0.0
+|    +--- com.google.android.datatransport:transport-api:2.2.0
+|    +--- com.google.android.datatransport:transport-backend-cct:2.2.1 (*)
+|    +--- com.google.android.datatransport:transport-runtime:2.2.1 (*)
+|    +--- com.google.android.gms:play-services-tasks:17.0.0 (*)
+|    +--- com.google.firebase:firebase-common:19.3.0 (*)
+|    +--- com.google.firebase:firebase-components:16.0.0 (*)
+|    +--- com.google.firebase:firebase-encoders-json:16.1.0 (*)
+|    +--- com.google.firebase:firebase-iid:20.1.5 -> 20.2.0 (*)
+|    +--- com.google.firebase:firebase-iid-interop:17.0.0 (*)
+|    +--- com.google.firebase:firebase-measurement-connector:18.0.0 (*)
+|    \--- com.squareup.okhttp3:okhttp:3.12.1 -> 3.12.10 (*)
++--- com.chibatching.kotpref:kotpref:2.6.0
++--- com.chibatching.kotpref:gson-support:2.6.0
+|    \--- com.chibatching.kotpref:kotpref:2.6.0
++--- com.github.chrisbanes:PhotoView:2.3.0
+|    \--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
++--- com.ryanjeffreybrooks:indefinitepagerindicator:1.0.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41 -> 1.3.72
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
+|    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
+|    \--- androidx.recyclerview:recyclerview:1.0.0 -> 1.1.0 (*)
++--- androidx.browser:browser:1.2.0
+|    +--- androidx.core:core:1.1.0 -> 1.3.0 (*)
+|    +--- androidx.annotation:annotation:1.1.0
+|    +--- com.google.guava:listenablefuture:1.0
+|    +--- androidx.collection:collection:1.1.0 (*)
+|    +--- androidx.concurrent:concurrent-futures:1.0.0
+|    |    +--- com.google.guava:listenablefuture:1.0
+|    |    \--- androidx.annotation:annotation:1.1.0
+|    \--- androidx.interpolator:interpolator:1.0.0 (*)
++--- com.github.marlonlom:timeago:4.0.3
++--- net.gotev:uploadservice:4.3.0
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.3.72 (*)
+|    +--- androidx.appcompat:appcompat:1.1.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71 -> 1.3.72 (*)
++--- com.github.nguyenhoanglam:ImagePicker:1.4.0
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 (*)
+|    +--- androidx.appcompat:appcompat:1.1.0 (*)
+|    +--- androidx.recyclerview:recyclerview:1.1.0 (*)
+|    +--- com.google.android.material:material:1.1.0 (*)
+|    +--- androidx.legacy:legacy-support-v4:1.0.0 (*)
+|    +--- androidx.core:core-ktx:1.2.0 -> 1.3.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 (*)
+|    +--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
+|    \--- com.github.bumptech.glide:glide:4.11.0 (*)
++--- it.xabaras.android:recyclerview-swipedecorator:1.2.2
++--- com.github.samanzamani.persiandate:PersianDate:0.8
+\--- project :spotlight
+     +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.61 -> 1.3.72 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.61 -> 1.3.72 (*)
+     +--- androidx.core:core-ktx:1.3.0 (*)
+     \--- androidx.appcompat:appcompat:1.1.0 (*)
+
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+BUILD SUCCESSFUL in 918ms
+1 actionable task: 1 executed

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -156,20 +156,21 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
 |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.4.1 (*)
-|    +--- androidx.room:room-ktx:2.2.5
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.32 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.4.1 (*)
-|    |    +--- androidx.room:room-common:2.2.5
+|    +--- androidx.room:room-ktx:2.2.5 -> 2.3.0
+|    |    +--- androidx.room:room-common:2.3.0
 |    |    |    \--- androidx.annotation:annotation:1.1.0
-|    |    \--- androidx.room:room-runtime:2.2.5
-|    |         +--- androidx.room:room-common:2.2.5 (*)
-|    |         +--- androidx.sqlite:sqlite-framework:2.0.1
-|    |         |    +--- androidx.annotation:annotation:1.0.2 -> 1.1.0
-|    |         |    \--- androidx.sqlite:sqlite:2.0.1
-|    |         |         \--- androidx.annotation:annotation:1.0.2 -> 1.1.0
-|    |         +--- androidx.sqlite:sqlite:2.0.1 (*)
-|    |         \--- androidx.arch.core:core-runtime:2.0.1 -> 2.1.0 (*)
-|    +--- androidx.room:room-runtime:2.2.5 (*)
+|    |    +--- androidx.room:room-runtime:2.3.0
+|    |    |    +--- androidx.room:room-common:2.3.0 (*)
+|    |    |    +--- androidx.sqlite:sqlite-framework:2.1.0
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    |    \--- androidx.sqlite:sqlite:2.1.0
+|    |    |    |         \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.sqlite:sqlite:2.1.0 (*)
+|    |    |    +--- androidx.arch.core:core-runtime:2.0.1 -> 2.1.0 (*)
+|    |    |    \--- androidx.annotation:annotation-experimental:1.1.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 -> 1.4.32 (*)
+|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1 (*)
+|    +--- androidx.room:room-runtime:2.2.5 -> 2.3.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5 -> 1.4.1 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5 -> 1.4.1 (*)
 |    +--- com.google.code.gson:gson:2.8.6
@@ -183,8 +184,8 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- androidx.recyclerview:recyclerview:1.1.0 (*)
 +--- com.google.android:flexbox:2.0.1
 +--- androidx.constraintlayout:constraintlayout:1.1.3 (*)
-+--- androidx.room:room-runtime:2.2.5 (*)
-+--- androidx.room:room-ktx:2.2.5 (*)
++--- androidx.room:room-runtime:2.3.0 (*)
++--- androidx.room:room-ktx:2.3.0 (*)
 +--- org.koin:koin-android-viewmodel:2.0.1
 |    +--- org.koin:koin-android-scope:2.0.1
 |    |    +--- org.koin:koin-android:2.0.1

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -142,11 +142,12 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    \--- androidx.constraintlayout:constraintlayout-solver:1.1.3
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.32 (*)
-|    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5
-|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.4.32 (*)
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.4.32
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.4.1
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1
+|    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.1
+|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.4.32 (*)
+|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0 -> 1.4.32
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.4.32 (*)
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    +--- androidx.lifecycle:lifecycle-livedata:2.3.0-alpha01 (*)
@@ -154,10 +155,10 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
-|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.3.5 (*)
+|    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.4.1 (*)
 |    +--- androidx.room:room-ktx:2.2.5
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.4.32 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.4.1 (*)
 |    |    +--- androidx.room:room-common:2.2.5
 |    |    |    \--- androidx.annotation:annotation:1.1.0
 |    |    \--- androidx.room:room-runtime:2.2.5
@@ -169,8 +170,8 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |         +--- androidx.sqlite:sqlite:2.0.1 (*)
 |    |         \--- androidx.arch.core:core-runtime:2.0.1 -> 2.1.0 (*)
 |    +--- androidx.room:room-runtime:2.2.5 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5 (*)
-|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5 -> 1.4.1 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5 -> 1.4.1 (*)
 |    +--- com.google.code.gson:gson:2.8.6
 |    \--- com.squareup.okhttp3:okhttp:3.12.10
 |         \--- com.squareup.okio:okio:1.15.0
@@ -204,8 +205,8 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |         |    \--- androidx.lifecycle:lifecycle-runtime:2.2.0 -> 2.3.0-alpha01 (*)
 |         \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
 +--- androidx.annotation:annotation:1.0.1 -> 1.1.0
-+--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1 -> 1.3.5 (*)
-+--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1 -> 1.3.5 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1 (*)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1 (*)
 +--- androidx.navigation:navigation-fragment-ktx:2.3.5
 |    +--- androidx.navigation:navigation-fragment:2.3.5
 |    |    +--- androidx.fragment:fragment:1.2.4 (*)
@@ -235,7 +236,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0-alpha01 (*)
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
-|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.3.5 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.4.1 (*)
 |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
 |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)

--- a/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
+++ b/scripts/extract_dependencies/stagingDebugRuntimeClasspath.txt
@@ -30,14 +30,17 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- androidx.databinding:databinding-adapters:4.1.3
 |    +--- androidx.databinding:databinding-common:4.1.3
 |    \--- androidx.databinding:databinding-runtime:4.1.3 (*)
-+--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.32
-|    \--- org.jetbrains:annotations:13.0
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31 (*)
 +--- com.github.chuckerteam.chucker:library:3.2.0
 |    +--- androidx.databinding:viewbinding:3.6.1 -> 4.1.3 (*)
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.32
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32 (*)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.5.31
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.31 (*)
 |    +--- com.google.android.material:material:1.1.0
 |    |    +--- androidx.annotation:annotation:1.0.1 -> 1.1.0
 |    |    +--- androidx.appcompat:appcompat:1.1.0
@@ -141,20 +144,20 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- androidx.constraintlayout:constraintlayout:1.1.3
 |    |    \--- androidx.constraintlayout:constraintlayout-solver:1.1.3
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.5.31 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.4.1
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1
 |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.1
-|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.4.32 (*)
-|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0 -> 1.4.32
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.4.32 (*)
+|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.5.31 (*)
+|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0 -> 1.5.31
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 -> 1.5.31 (*)
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-livedata-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    +--- androidx.lifecycle:lifecycle-livedata:2.3.0-alpha01 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.3.0-alpha01
 |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0-alpha01 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.5.31 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.5.31 (*)
 |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0 -> 1.4.1 (*)
 |    +--- androidx.room:room-ktx:2.2.5 -> 2.3.0
 |    |    +--- androidx.room:room-common:2.3.0
@@ -168,7 +171,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    |    +--- androidx.sqlite:sqlite:2.1.0 (*)
 |    |    |    +--- androidx.arch.core:core-runtime:2.0.1 -> 2.1.0 (*)
 |    |    |    \--- androidx.annotation:annotation-experimental:1.1.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 -> 1.4.32 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 -> 1.5.31 (*)
 |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1 (*)
 |    +--- androidx.room:room-runtime:2.2.5 -> 2.3.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5 -> 1.4.1 (*)
@@ -176,9 +179,6 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- com.google.code.gson:gson:2.8.6
 |    \--- com.squareup.okhttp3:okhttp:3.12.10
 |         \--- com.squareup.okio:okio:1.15.0
-+--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.4.32
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32 (*)
-|    \--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.32 (*)
 +--- androidx.appcompat:appcompat:1.1.0 (*)
 +--- androidx.cardview:cardview:1.0.0 (*)
 +--- androidx.recyclerview:recyclerview:1.1.0 (*)
@@ -190,7 +190,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    +--- org.koin:koin-android-scope:2.0.1
 |    |    +--- org.koin:koin-android:2.0.1
 |    |    |    \--- org.koin:koin-core:2.0.1
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.4.32 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 -> 1.5.31 (*)
 |    |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.0-alpha01 (*)
 |    \--- androidx.lifecycle:lifecycle-extensions:2.0.0 -> 2.2.0
@@ -224,36 +224,36 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
 |    |    +--- androidx.navigation:navigation-common-ktx:2.3.5
 |    |    |    +--- androidx.navigation:navigation-common:2.3.5 (*)
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.31 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.31 (*)
 |    |    |    |    +--- androidx.annotation:annotation:1.1.0
 |    |    |    |    \--- androidx.core:core:1.3.0 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.5.31 (*)
 |    |    |    +--- androidx.activity:activity:1.1.0 (*)
 |    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.2.0 -> 2.3.0-alpha01
 |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0-alpha01 (*)
-|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.4.32 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.60 -> 1.5.31 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0 -> 1.4.1 (*)
 |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.1.0
 |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.31 (*)
 |    +--- androidx.fragment:fragment-ktx:1.2.4
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.4.32 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.50 -> 1.5.31 (*)
 |    |    +--- androidx.fragment:fragment:1.2.4 (*)
 |    |    +--- androidx.activity:activity-ktx:1.1.0 (*)
 |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.3.0 (*)
 |    |    +--- androidx.collection:collection-ktx:1.1.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.4.32 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.20 -> 1.5.31 (*)
 |    |    |    \--- androidx.collection:collection:1.1.0 (*)
 |    |    +--- androidx.lifecycle:lifecycle-livedata-core-ktx:2.2.0 -> 2.3.0-alpha01 (*)
 |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.31 (*)
 +--- androidx.navigation:navigation-ui-ktx:2.3.5
 |    +--- androidx.navigation:navigation-ui:2.3.5
 |    |    +--- androidx.navigation:navigation-runtime:2.3.5 (*)
@@ -262,7 +262,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    |    +--- com.google.android.material:material:1.0.0 -> 1.1.0 (*)
 |    |    \--- androidx.transition:transition:1.3.0 (*)
 |    +--- androidx.navigation:navigation-runtime-ktx:2.3.5 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.4.32 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.31 (*)
 +--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
 +--- androidx.legacy:legacy-support-v4:1.0.0
 |    +--- androidx.core:core:1.0.0 -> 1.3.0 (*)
@@ -439,8 +439,7 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 +--- com.github.chrisbanes:PhotoView:2.3.0
 |    \--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 +--- com.ryanjeffreybrooks:indefinitepagerindicator:1.0.10
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41 -> 1.3.72
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.32 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41 -> 1.5.31 (*)
 |    +--- androidx.appcompat:appcompat:1.0.0 -> 1.1.0 (*)
 |    \--- androidx.recyclerview:recyclerview:1.0.0 -> 1.1.0 (*)
 +--- androidx.browser:browser:1.2.0
@@ -454,26 +453,29 @@ stagingDebugRuntimeClasspath - Runtime classpath of compilation 'stagingDebug' (
 |    \--- androidx.interpolator:interpolator:1.0.0 (*)
 +--- com.github.marlonlom:timeago:4.0.3
 +--- net.gotev:uploadservice:4.3.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.4.32 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.71 -> 1.5.31 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71 -> 1.3.72 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.71 -> 1.5.31 (*)
 +--- com.github.nguyenhoanglam:ImagePicker:1.4.0
-|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.4.32 (*)
+|    +--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72 -> 1.5.31 (*)
 |    +--- androidx.appcompat:appcompat:1.1.0 (*)
 |    +--- androidx.recyclerview:recyclerview:1.1.0 (*)
 |    +--- com.google.android.material:material:1.1.0 (*)
 |    +--- androidx.legacy:legacy-support-v4:1.0.0 (*)
 |    +--- androidx.core:core-ktx:1.2.0 -> 1.3.0 (*)
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.5.31 (*)
 |    +--- androidx.lifecycle:lifecycle-extensions:2.2.0 (*)
 |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0 (*)
 |    \--- com.github.bumptech.glide:glide:4.11.0 (*)
 +--- it.xabaras.android:recyclerview-swipedecorator:1.2.2
 +--- com.github.samanzamani.persiandate:PersianDate:0.8
-\--- project :spotlight
-     +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.32 (*)
-     +--- androidx.core:core-ktx:1.3.0 (*)
-     \--- androidx.appcompat:appcompat:1.1.0 (*)
++--- project :spotlight
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31 (*)
+|    +--- androidx.core:core-ktx:1.3.0 (*)
+|    \--- androidx.appcompat:appcompat:1.1.0 (*)
+\--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.5.31
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31 (*)
+     \--- org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.5.31 (*)
 
 (*) - dependencies omitted (listed previously)
 

--- a/spotlight/build.gradle
+++ b/spotlight/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29

--- a/spotlight/build.gradle
+++ b/spotlight/build.gradle
@@ -26,7 +26,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Added some scripts for retrieve and generate dependencies list
Bumped Kotlin to 1.5.31 (Enough for starting Jetpack Compose)

To bump Kotlin, Room and Coroutines had to be upgraded. but because of bumping Kotlin was the goal, these are not upgrade to latest version.